### PR TITLE
Fix the return type of felem_is_zero_int which should be int.

### DIFF
--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -700,7 +700,7 @@ static limb felem_is_zero(const felem in)
     return (zero | two224m96p1 | two225m97p2);
 }
 
-static limb felem_is_zero_int(const felem in)
+static int felem_is_zero_int(const void *in)
 {
     return (int)(felem_is_zero(in) & ((limb) 1));
 }
@@ -1365,7 +1365,6 @@ static void make_points_affine(size_t num, felem points[ /* num */ ][3],
                                              sizeof(felem),
                                              tmp_felems,
                                              (void (*)(void *))felem_one,
-                                             (int (*)(const void *))
                                              felem_is_zero_int,
                                              (void (*)(void *, const void *))
                                              felem_assign,

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -979,7 +979,7 @@ static limb smallfelem_is_zero(const smallfelem small)
     return result;
 }
 
-static int smallfelem_is_zero_int(const smallfelem small)
+static int smallfelem_is_zero_int(const void *small)
 {
     return (int)(smallfelem_is_zero(small) & ((limb) 1));
 }
@@ -1983,7 +1983,6 @@ static void make_points_affine(size_t num, smallfelem points[][3],
                                              sizeof(smallfelem),
                                              tmp_smallfelems,
                                              (void (*)(void *))smallfelem_one,
-                                             (int (*)(const void *))
                                              smallfelem_is_zero_int,
                                              (void (*)(void *, const void *))
                                              smallfelem_assign,

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -886,7 +886,7 @@ static limb felem_is_zero(const felem in)
     return is_zero;
 }
 
-static int felem_is_zero_int(const felem in)
+static int felem_is_zero_int(const void *in)
 {
     return (int)(felem_is_zero(in) & ((limb) 1));
 }
@@ -1805,7 +1805,6 @@ static void make_points_affine(size_t num, felem points[][3],
                                              sizeof(felem),
                                              tmp_felems,
                                              (void (*)(void *))felem_one,
-                                             (int (*)(const void *))
                                              felem_is_zero_int,
                                              (void (*)(void *, const void *))
                                              felem_assign,


### PR DESCRIPTION
Change argument type of xxxelem_is_zero_int to const void*
to avoid the need of type casts.

Fixes #4413

Reviewed-by: Andy Polyakov <appro@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/4450)

(cherry picked from commit c55b786a8911cef41f890735ba5fde79e116e055)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
